### PR TITLE
feat: refresh token immediately if token expired

### DIFF
--- a/src/lib/cookieMonster.jsx
+++ b/src/lib/cookieMonster.jsx
@@ -25,3 +25,8 @@ export function deleteCookie(cname) {
   const cvalue = getCookie(cname);
   setCookie(cname, cvalue, -1);
 }
+
+export function checkCookie(cname) {
+  // get a cookie and check if it's expired
+  return getCookie(cname) !== "";
+}

--- a/src/pages/lost-and-found.jsx
+++ b/src/pages/lost-and-found.jsx
@@ -46,6 +46,15 @@ export default function Home() {
   };
 
   const fetchMessages = async () => {
+    // immediately refresh token if it has expired already
+    // saves ~2s because iemb is slow...
+    if (
+      !checkCookie("auth_token") ||
+      !checkCookie("sess_id") ||
+      !checkCookie("veri_token")
+    ) {
+      return await refreshToken();
+    }
     const response = await fetch("/api/getBoard", {
       method: "POST",
       headers: {

--- a/src/pages/service.jsx
+++ b/src/pages/service.jsx
@@ -46,6 +46,15 @@ export default function Home() {
   };
 
   const fetchMessages = async () => {
+    // immediately refresh token if it has expired already
+    // saves ~2s because iemb is slow...
+    if (
+      !checkCookie("auth_token") ||
+      !checkCookie("sess_id") ||
+      !checkCookie("veri_token")
+    ) {
+      return await refreshToken();
+    }
     const response = await fetch("/api/getBoard", {
       method: "POST",
       headers: {

--- a/src/pages/student.jsx
+++ b/src/pages/student.jsx
@@ -2,7 +2,12 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-import { getCookie, setCookie } from "../lib/cookieMonster";
+import {
+  getCookie,
+  setCookie,
+  checkCookie,
+  deleteCookie,
+} from "../lib/cookieMonster";
 
 import Navbar from "../components/Navbar";
 import { Snackbar, Alert, Stack } from "@mui/material";
@@ -46,6 +51,15 @@ export default function Home() {
   };
 
   const fetchMessages = async () => {
+    // immediately refresh token if it has expired already
+    // saves ~2s because iemb is slow...
+    if (
+      !checkCookie("auth_token") ||
+      !checkCookie("sess_id") ||
+      !checkCookie("veri_token")
+    ) {
+      return await refreshToken();
+    }
     const response = await fetch("/api/getBoard", {
       method: "POST",
       headers: {


### PR DESCRIPTION
Saves ~2s of doing an unsuccessful fetch with an expired token. (iemb is just so slow)