### PR TITLE
fix: temporarily disable attachments on posts

### DIFF
--- a/src/pages/[boardID]/[pid].jsx
+++ b/src/pages/[boardID]/[pid].jsx
@@ -45,7 +45,7 @@ const Post = () => {
   };
 
   const fetchPost = async (pid, boardID) => {
-    const response = await fetch("/api/getPostWithAttachmentURL", {
+    const response = await fetch("/api/getPost", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
chromium executable is not available in deployment